### PR TITLE
Fix multiple bugs: resource leak, buffer overflow, incorrect output

### DIFF
--- a/src/cmake.c
+++ b/src/cmake.c
@@ -30,7 +30,7 @@ static void write_header(FILE* file, project_config_t* config) {
     fprintf(file, "# For additional custom CMake use CMakeLists.extra.cmake instead.\n\n");
 
     fprintf(file, "cmake_minimum_required(VERSION 3.14)\n");
-    fprintf(file, "project(%s)\n\n", config->name);
+    fprintf(file, "project(\"%s\")\n\n", config->name);
 
     if (config->has_c_standard) {
         fprintf(file, "set(CMAKE_C_STANDARD %d)\n", config->c_standard);

--- a/src/init.c
+++ b/src/init.c
@@ -405,7 +405,7 @@ static int init_existing_project(const char* path, const char* language_option, 
     fprintf(stdout, "Initialized Craft project at '%s'\n\n", path);
 
     fprintf(stdout, "language: %s\n", config.language);
-    fprintf(stdout, "type: executable\n");
+    fprintf(stdout, "type: %s\n", config.build_type);
 
     fprintf(stdout, "source dirs:");
     for (int i = 0; i < config.source_dir_count; i++) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -101,10 +101,11 @@ int remove_dir(const char* path) {
 // Removes a directory and keeps track of counts
 int remove_dir_count(const char* path, unsigned int* count, unsigned int* bytes) {
     struct stat statbuff;
-    stat(path, &statbuff);
-    *bytes += statbuff.st_size;
+    if (stat(path, &statbuff) == 0) {
+        *bytes += statbuff.st_size;
+    }
     (*count)++;
-    
+
     return remove_dir_recursive(path, count, bytes);
 }
 
@@ -132,9 +133,15 @@ int copy_file(const char* source, const char* dest) {
 
     // Open files
     FILE* in = fopen(source, "rb");
-    FILE* out = fopen(dest, "wb");
-    if (!in || !out) {
+    if (!in) {
         fprintf(stderr, "Error: Failed to copy file.\n");
+        return -1;
+    }
+
+    FILE* out = fopen(dest, "wb");
+    if (!out) {
+        fprintf(stderr, "Error: Failed to copy file.\n");
+        fclose(in);
         return -1;
     }
 
@@ -189,7 +196,10 @@ int copy_dir_contents(const char* source_dir, const char* dest_dir, const char**
         // If entry is directory, copy contents recursively
         if (entry.is_dir) {
             mkdir(dest_path, 0755);
-            copy_dir_contents(source_path, dest_path, excludes, exclude_count);
+            if (copy_dir_contents(source_path, dest_path, excludes, exclude_count) != 0) {
+                close_dir(dir);
+                return -1;
+            }
         }
         // Entry is a file, copy contents to destination
         else {
@@ -285,6 +295,11 @@ int get_template_directory(char* buffer, size_t buffer_size, const char* type, c
 static int levenshtein_distance(const char* s1, const char* s2) {
     int len1 = (int)strlen(s1);
     int len2 = (int)strlen(s2);
+
+    // Clamp lengths to prevent buffer overflow (matrix is 64x64)
+    if (len1 > 62) len1 = 62;
+    if (len2 > 62) len2 = 62;
+
     int matrix[64][64];
 
     for (int i = 0; i <= len1; i++) matrix[i][0] = i;


### PR DESCRIPTION
## Summary

- **Fix resource leak in `copy_file`** (`utils.c`): If `fopen(dest)` fails after `fopen(source)` succeeds, the input file handle was never closed. Now properly closes `in` before returning.
- **Fix buffer overflow in `levenshtein_distance`** (`utils.c`): The function uses a fixed `matrix[64][64]` on the stack but never validates string lengths. Strings longer than 63 characters cause out-of-bounds writes. Added clamping to prevent overflow.
- **Fix unquoted project name in CMake generation** (`cmake.c`): `project(name)` should be `project("name")` to correctly handle project names containing spaces or special characters.
- **Fix hardcoded "type: executable" in `init_existing_project`** (`init.c`): When initializing a project in an existing directory, the output always printed `type: executable` regardless of the actual build type from config. Now prints the real `config.build_type`.
- **Fix unchecked recursive return in `copy_dir_contents`** (`utils.c`): Errors from recursive subdirectory copies were silently ignored. Now properly propagated up the call stack.
- **Fix unchecked `stat()` result in `remove_dir_count`** (`utils.c`): `stat()` return value was not checked before accessing `st_size`, which could use uninitialized data if the path doesn't exist.

## Test plan

- [ ] Verify `craft init` in an existing project directory prints the correct build type (not always "executable")
- [ ] Verify `craft build` generates `project("name")` in CMakeLists.txt
- [ ] Test with a project name containing spaces to confirm CMake handles it correctly
- [ ] Verify file copy operations properly propagate errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)